### PR TITLE
add activate to redirect when user logins with temporary password

### DIFF
--- a/mobile_app/src/core/apis/url.ts
+++ b/mobile_app/src/core/apis/url.ts
@@ -1,3 +1,3 @@
-const url = "http://15.164.48.52:7000";
+const url = "https://linkerbell.kr";
 
 export default url;

--- a/mobile_app/src/hooks/useAuth.ts
+++ b/mobile_app/src/hooks/useAuth.ts
@@ -19,6 +19,7 @@ export default function useAuth() {
   const err = useSelector((state: RootState) => state.auth.err);
   const isLogin = useSelector((state: RootState) => state.auth.isLogin);
   const isOauthLogin = useSelector((state: RootState) => state.auth.isOauth);
+  const activate = useSelector((state: RootState) => state.auth.activate);
   const dispatch = useDispatch();
 
   const onLogin = useCallback(
@@ -64,5 +65,6 @@ export default function useAuth() {
     onLogOut,
     handleErr,
     isOauthLogin,
+    activate,
   };
 }

--- a/mobile_app/src/models/AuthParamList.ts
+++ b/mobile_app/src/models/AuthParamList.ts
@@ -6,4 +6,6 @@ export type AuthParamList = {
   Loding: undefined;
   UserDetail: undefined;
   Welcome: undefined;
+  VerifyEmail: undefined;
+  EditPassword: undefined;
 };

--- a/mobile_app/src/routes/bottomTabNav.tsx
+++ b/mobile_app/src/routes/bottomTabNav.tsx
@@ -10,7 +10,7 @@ import Mypage from "../screens/myPage";
 import useLinkData from "../hooks/useLinkData";
 import useApp from "../hooks/useApp";
 import EditPassword from "../screens/editPassword";
-import verifyEmail from "../screens/verifyEmail";
+import VerifyEmail from "../screens/verifyEmail";
 
 type NavProps = {
   focused: boolean;
@@ -28,7 +28,7 @@ const HomeStack = (): JSX.Element => {
       <Stack.Screen name="List" component={List} />
       <Stack.Screen name="Mypage" component={Mypage} />
       <Stack.Screen name="EditPassword" component={EditPassword} />
-      <Stack.Screen name="verifyEmail" component={verifyEmail} />
+      <Stack.Screen name="VerifyEmail" component={VerifyEmail} />
     </Stack.Navigator>
   );
 };
@@ -50,6 +50,7 @@ const BottomTabNav = (): JSX.Element => {
     updateCategoriesUrlList(all_category_url_list);
   }, [all_category_url_list]);
   useEffect(() => {
+    EditPassword;
     if (isDarkmode) setNavColor("#1E1E1E");
     else setNavColor("#fff");
   }, [isDarkmode]);

--- a/mobile_app/src/routes/stackNav.tsx
+++ b/mobile_app/src/routes/stackNav.tsx
@@ -7,7 +7,8 @@ import Loding from "../screens/loading";
 import UserDetail from "../screens/userDetail";
 import Home from "../screens/home";
 import Welcome from "../screens/welcome";
-import verifyEmail from "../screens/verifyEmail";
+import VerifyEmail from "../screens/verifyEmail";
+import EditPassword from "../screens/editPassword";
 
 const StackNav = (): JSX.Element => {
   const Stack = createStackNavigator();
@@ -23,7 +24,8 @@ const StackNav = (): JSX.Element => {
       <Stack.Screen name="UserDetail" component={UserDetail} />
       <Stack.Screen name="Home" component={Home} />
       <Stack.Screen name="Welcome" component={Welcome} />
-      <Stack.Screen name="verifyEmail" component={verifyEmail} />
+      <Stack.Screen name="EditPassword" component={EditPassword} />
+      <Stack.Screen name="VerifyEmail" component={VerifyEmail} />
     </Stack.Navigator>
   );
 };

--- a/mobile_app/src/screens/editPassword.tsx
+++ b/mobile_app/src/screens/editPassword.tsx
@@ -54,7 +54,7 @@ const EditPassword = ({
   };
 
   const hanldePressLinkToFindPW = (): void => {
-    navigation.navigate("verifyEmail");
+    navigation.navigate("VerifyEmail");
   };
 
   return (

--- a/mobile_app/src/screens/home.tsx
+++ b/mobile_app/src/screens/home.tsx
@@ -25,7 +25,7 @@ const Home = ({
   const { onHome, categories } = useLinkData();
   const [isModalVisible, setModalVisible] = useState(false);
   const { getCopiedUrl, copiedUrl } = useServices();
-  const { isOauthLogin } = useAuth();
+  const { isOauthLogin, activate } = useAuth();
   const handleAllListbtnPress = () => {
     navigation.navigate("List", { category_id: 0 });
   };
@@ -43,6 +43,13 @@ const Home = ({
     isOauthLogin && getCategoryList();
     setData(categories);
   }, []);
+
+  useEffect(() => {
+    if (activate === 2) {
+      navigation.push("EditPassword");
+      //! 다음 로그인까지 1로 변경이 안되므로 여기서 바꿔줘야함.
+    }
+  });
 
   useEffect(() => {
     setData(categories);

--- a/mobile_app/src/screens/home.tsx
+++ b/mobile_app/src/screens/home.tsx
@@ -47,7 +47,7 @@ const Home = ({
   useEffect(() => {
     if (activate === 2) {
       navigation.push("EditPassword");
-      //! 다음 로그인까지 1로 변경이 안되므로 여기서 바꿔줘야함.
+      //! 다음 로그인까지 1로 변경이 안되므로 클라이언트에서 바꿔줘야함
     }
   });
 

--- a/mobile_app/src/screens/myPage.tsx
+++ b/mobile_app/src/screens/myPage.tsx
@@ -47,11 +47,11 @@ const Mypage = ({
       return (
         <React.Fragment>
           <EmailView>
-            <EmailText>{"이메일"}</EmailText>
+            <EmailText>{"👤  이메일"}</EmailText>
             <Email>{email}</Email>
           </EmailView>
           <EditPWBtn onPress={onEditPassword}>
-            <EmailText>{"비밀번호 수정"}</EmailText>
+            <EmailText>{"🔐  비밀번호 수정"}</EmailText>
           </EditPWBtn>
         </React.Fragment>
       );
@@ -70,7 +70,7 @@ const Mypage = ({
       />
       {renderAuthInfo()}
       <LogOutBtn onPress={handleLogOutBtnPress}>
-        <LogOutText>{"로그아웃"}</LogOutText>
+        <LogOutText>{"👋  로그아웃"}</LogOutText>
       </LogOutBtn>
     </HContainer>
   );

--- a/mobile_app/src/screens/signIn.tsx
+++ b/mobile_app/src/screens/signIn.tsx
@@ -10,7 +10,7 @@ import { StackNavigationProp } from "@react-navigation/stack";
 import { LoginValue } from "../models/LoginTypes";
 import { validateValue } from "../core/utils/validate";
 import { style } from "../styles/SigninStyles/StyleIndex";
-import { LinkToFindPW, FindPWText } from "../styles/FindPW/SLinkToFindPW.ts";
+import { LinkToFindPW, FindPWText } from "../styles/FindPW/SLinkToFindPW";
 
 import Input from "../components/Input";
 import Btn from "../components/Btn";
@@ -27,7 +27,13 @@ const Login = ({
     password: "",
     err: {},
   });
-  const { onLogin, isLogin, err: requestError, handleErr } = useAuth();
+  const {
+    onLogin,
+    isLogin,
+    activate,
+    err: requestError,
+    handleErr,
+  } = useAuth();
 
   useEffect(() => {
     validateValue(value, setValue);
@@ -45,7 +51,7 @@ const Login = ({
     onLogin({ email, password });
   };
   const hanldePressLinkToFindPW = (): void => {
-    navigation.navigate("verifyEmail");
+    navigation.navigate("VerifyEmail");
   };
   return (
     <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>

--- a/mobile_app/src/screens/verifyEmail.tsx
+++ b/mobile_app/src/screens/verifyEmail.tsx
@@ -16,7 +16,7 @@ export type FindPWType = {
   err?: any;
 };
 
-const verifyEmail = ({
+const VerifyEmail = ({
   navigation,
 }: {
   navigation: StackNavigationProp<any>;
@@ -62,4 +62,4 @@ const verifyEmail = ({
   );
 };
 
-export default verifyEmail;
+export default VerifyEmail;


### PR DESCRIPTION
- 임시 비밀 번호 발급 후 재로그인시 activate 상태 반영하여 비밀번호수정 페이지로 네비게이트 하는 로직을 추가했습니다. 
- 비밀 번호 수정 후 다음 로그인까지 activate이 변경되지 않아서 클라이언트쪽에서 스토어에 activate값 변경하는 게 있어야 합니다..! 